### PR TITLE
Fix VBC to run with latest version of rvinecopulib (‘0.7.2.1.0’)

### DIFF
--- a/R/rosenblatt.R
+++ b/R/rosenblatt.R
@@ -1,28 +1,66 @@
 
 #' 
-rosenblatt <- function (x, model, cores = 1, randomize_discrete = TRUE) 
-{
-  assertthat::assert_that(inherits(model, c("bicop_dist", "vinecop_dist", 
-                                "vine_dist")), assertthat::is.number(cores))
-  to_col <- if (inherits(model, "bicop_dist")) 
-    FALSE
-  else (dim(model)[1] == 1)
-  x <- rvinecopulib:::if_vec_to_matrix(x, to_col)
-  col_names <- colnames(x)
+#' 
+#' 
+rosenblatt <- function(x, model, cores = 1, randomize_discrete = TRUE) {
+  assertthat::assert_that(
+    inherits(model, c("bicop_dist", "vinecop_dist", "vine_dist")),
+    assertthat::is.number(cores)
+  )
+  
   if (inherits(model, "bicop_dist")) {
-    model <- vinecop_dist(list(list(model)), cvine_structure(1:2), 
-                          var_types = model$var_types)
+    model <- vinecop_dist(
+      list(list(model)),
+      cvine_structure(1:2),
+      var_types = model$var_types
+    )
   }
-  if (inherits(model, "vinecop_dist")) {
-    assertthat::assert_that(all((x >= 0) & (x <= 1)))
-    x <- pmin(pmax(x, 1e-10), 1 - 1e-10)
-    x <- rvinecopulib:::vinecop_rosenblatt_cpp(x, model, cores, 
-                                               randomize_discrete, 
-                                               rvinecopulib:::get_seeds())
+  
+  if (inherits(model, "vine_dist")) {
+    x <- expand_factors(x)
+    if (!is.null(model$names)) {
+      x <- x[, model$names, drop = FALSE]
+    }
+    x <- compute_pseudo_obs(x, model)
+    model <- model$copula
   }
-  else {
-    stop("Model must be of class bicop_dist or vinecop_dist")
-  }
-  colnames(x) <- col_names[1:ncol(x)]
+  
+  # model is now a vinecop_dist
+  assertthat::assert_that(all((x >= 0) & (x <= 1)))
+  x <- as.matrix(x)
+  x <- pmin(pmax(x, 1e-10), 1 - 1e-10)
+  x <- rvinecopulib:::if_vec_to_matrix(x, dim(model)[1] == 1)
+  x <- rvinecopulib:::vinecop_rosenblatt_cpp(x, model, cores, randomize_discrete, rvinecopulib:::get_seeds())
+  colnames(x) <- unique(model$names)
+  
   x
+}
+
+inverse_rosenblatt <- function(u, model, cores = 1) {
+  assertthat::assert_that(
+    all((u > 0) & (u < 1)),
+    inherits(model, c("bicop_dist", "vinecop_dist", "vine_dist")),
+    assertthat::is.number(cores)
+  )
+  
+  to_col <- if (inherits(model, "bicop_dist")) FALSE else (dim(model)[1] == 1)
+  u <- rvinecopulib:::if_vec_to_matrix(u, to_col)
+  
+  if (inherits(model, "bicop_dist")) {
+    model <- vinecop_dist(
+      list(list(model)),
+      cvine_structure(1:2),
+      var_types = model$var_types
+    )
+  }
+  
+  if (inherits(model, "vinecop_dist")) {
+    u <- rvinecopulib:::vinecop_inverse_rosenblatt_cpp(u, model, cores)
+  } else {
+    u <- rvinecopulib:::vinecop_inverse_rosenblatt_cpp(u, model$copula, cores)
+    u <- rvinecopulib:::dpq_marg(u, model, "q")
+  }
+  colnames(u) <- unique(model$names)
+  
+  u
 }


### PR DESCRIPTION
The current version of VBC is not compatible with the latest version of rvinecopulib (0.7.2.1.0) when being applied to zero-inflated variables.

Before, applying the vbc function runs in the following error (here using the VBC example):


![VBC_error](https://github.com/user-attachments/assets/b5069f57-eb51-43ca-b288-18feaf61e59a)


I slightly modified the rosenblatt.R file (dimension and data format mismatch), so the error disappears:


![VBC_fixed](https://github.com/user-attachments/assets/2513aec2-6c8b-4d59-9977-00a92463573d)
